### PR TITLE
Rewrite git skill for stronger agent adherence

### DIFF
--- a/skills/git/SKILL.md
+++ b/skills/git/SKILL.md
@@ -1,74 +1,158 @@
 ---
 name: git
-description: Guidelines for validation, staging, amending, and commit messages.
+description: >-
+  Guidelines for validation, staging, amending, and commit messages.
+  Load this skill whenever you are about to run git add, git commit,
+  or git push.
 ---
 
 # Git
 
-## Validate Changes
-Before committing any changes, ensure that your work does not break the application and meets all quality standards.
-Run the `validate` task just prior to commit:
+When working with Git, follow these rules. Violating any of them
+produces commits that fail project standards.
+
+## When To Apply This Skill
+
+Load this skill and follow these rules whenever you are about to:
+
+- Stage files (`git add`)
+- Create a commit (`git commit`)
+- Amend a commit (`git commit --amend`)
+- Push commits (`git push`)
+
+If you have already committed without following these rules,
+amend the commit before pushing.
+
+## 1. Validate Before Committing
+
+Before committing, verify that your changes do not break the
+project and are tidy. Run whatever validation the project provides:
+
+- If the project has a build or test command, run it (e.g.,
+  `make test`, `go test ./...`, `npm test`, `cargo test`).
+- If the project has a linter or formatter, run it and fix any
+  issues it reports.
+- If you created temporary files, debug output, or commented-out
+  code during development, remove them before staging.
+
+Do not commit changes that fail validation. Fix issues first,
+then re-validate.
+
+## 2. Stage Deliberately
+
+Stage only the files you have changed as part of your current
+stream of work. Never use `git add .` — it stages everything,
+including files you did not intend to commit.
+
+Correct:
 
 ```bash
-task validate
+git add path/to/file.go path/to/file_test.go
 ```
 
-## Stage Changes
-When staging changes, stage only the files that you have changed as part of your current stream of work
+Also correct (staging a whole deliberate folder):
 
 ```bash
-git add ./path/to/file ./path/to/file2
+git add path/to/folder/
 ```
 
-⚠️ Never stage changes by adding the whole directory:
+Wrong — do not do this:
 
 ```bash
 git add .
 ```
 
-Instead, if you wish to stage folders, stage those also deliberately:
+After staging, review what you are about to commit:
 
 ```bash
-git add path/to/folder
+git diff --staged --stat
+git diff --staged
 ```
 
-## Amend Commits
-If you need to update the previous commit (e.g., to squash changes or fix a mistake), append changes to the last commit:
+Confirm that only intended changes are staged. If you see
+unrelated changes, unstage them with `git reset HEAD <file>`
+and re-stage correctly.
+
+## 3. Amend When Fixing
+
+If you need to update your most recent commit (to fix a mistake,
+add a missing file, or improve the message), amend it rather
+than creating a new commit:
 
 ```bash
 git commit --amend
 ```
 
-If you have already pushed, you will need to force push:
+If you have already pushed the commit, force-push with lease:
+
 ```bash
 git push --force-with-lease
 ```
 
-## Write Commit Messages
-Commit messages should follow the standard format:
+## 4. Write Commit Messages
 
-#### Title
-Maximally 72 characters, descriptive, using imperative mood (e.g., "Deploy changes automatically" not "Deployed changes").
+Every commit must have a title and a body. Both are required.
 
-#### Body
-Maximally 72 characters, Explain **why** the change was made (justification), not just **what** changed. Use headers for structured context if applicable:
+### Title
+
+- Maximum 72 characters.
+- Use imperative mood: "Add validation step" not "Added
+  validation step" or "Adds validation step".
+- Summarize what the change does at a high level.
+
+### Body
+
+- Maximum 72 characters per line.
+- Explain **why** the change was made, not just what changed.
+- Structure the body using these headers:
 
 ```
 Design:
-  Describe the design of the change here.
+  Describe the technical approach — how the change is
+  implemented and why that approach was chosen.
 
 Tradeoffs:
-  Explain any tradeoffs (performance, complexity, etc).
+  Note any tradeoffs: performance costs, added complexity,
+  alternative approaches considered and rejected.
 
 Justification:
-  Provide the reasoning for this change.
+  State why this change is needed — the problem it solves
+  or the improvement it delivers.
 ```
 
-#### Co-author
-If pair programming or crediting others, add co-authors at the end of the body:
+Example of a well-formed commit message:
 
 ```
-Co-authored-by: NAME <NAME@EXAMPLE.COM>
+Add pre-commit validation guide to git skill
+
+Design:
+  Replace the project-specific "task validate" instruction
+  with generic validation guidance that works in any
+  project. The new text describes checking build, tests,
+  linters, and removing temporary artifacts.
+
+Tradeoffs:
+  The generic guidance is less precise than a concrete
+  command, but ensures the skill is usable across all
+  projects rather than only those using Taskfile.
+
+Justification:
+  The previous instruction referenced a tool that does not
+  exist in most repositories, causing agents to skip the
+  entire validation step. Generic guidance ensures the
+  validation habit is established regardless of tooling.
 ```
 
-Coding agents (e.g. Gemini, Claude, Antigravity) are all pair-programmers, and should ensure their own emails are added in "Co-Authored-By".
+### Co-authored-by
+
+When an AI coding agent (Claude, Gemini, Copilot, etc.)
+assisted in producing the commit, add a `Co-authored-by`
+trailer at the end of the body. Use the agent's known
+identity. If the agent's email is not known, use a
+placeholder consistent with the project's conventions.
+
+For example:
+
+```
+Co-authored-by: Claude <claude@anthropic.com>
+```


### PR DESCRIPTION
## Summary

The git skill had near-zero adherence: across 15+ AI-authored commits, none followed the structured commit format, none ran validation, and none included co-author trailers. Six root causes were identified and each is addressed in this rewrite.

## Changes

1. **New "When To Apply" section** — explicit trigger conditions so agents know exactly when to load this skill (`git add`, `git commit`, `git commit --amend`, `git push`)

2. **Generic validation guidance** — replaces `task validate` (project-specific, absent in most repos) with guidance to run whatever build/test/lint commands the project provides, plus cleanup of temporary artifacts

3. **Post-stage review step** — now instructs running `git diff --staged` to catch accidental staging before committing

4. **Numbered workflow** (1→2→3→4) — mirrors natural commit sequence: validate → stage → review staged → commit with proper format → amend if needed

5. **Concrete commit message example** — full formatted example gives agents a template to copy, rather than abstract rules to interpret

6. **Achievable co-author instruction** — acknowledges agents may not know their email, suggests a project-consistent placeholder